### PR TITLE
Release 0.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ install:
 before_script:
   - pip install -r requirements-dev.txt
 script:
-  - py.test --doctest-modules --pep8 tmdb3 -v --cov tmdb3 --cov-report term-missing
+  - tox
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+os: linux
+dist: xenial
 language: python
 python:
   - "3.6-dev"
   - "3.7-dev"
+  - "3.8-dev"
 install:
   - pip install -r requirements.txt
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## [0.8.0] - 2019/03/17
+- CI integration with coverage
+- Add tests
 - Add `CHANGELOG.md` file
-- Add `Python 3.6+` support (with fstring feature implemented)
-- Drop `Python2` support
+- Add Python 3.6+ support
+- Drop Python2 support
 ## [0.7.2] - 2015/01/18
 - Add similar and keywords to TV Series
 - Fix unicode issues with search result object names

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 PYTHON3-TMDB3
 =============
 
+[![Build Status](https://travis-ci.com/opacam/python3-tmdb3.svg?branch=master)](https://travis-ci.com/opacam/python3-tmdb3)
+[![Coverage Status](https://coveralls.io/repos/github/opacam/python3-tmdb3/badge.svg?branch=master)](https://coveralls.io/github/opacam/python3-tmdb3?branch=master)
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/opacam/python3-tmdb3/issues)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+
 This Python3 module implements the v3 API for
 [TheMovieDb.org](<https://www.themoviedb.org/>) , allowing access to movie,
 tvshow, cast information, as well as related artwork. More information can be

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ lxml
 black
 httpretty
 pytest
-pytest-pep8
 pytest-cov==2.5.0
 python-coveralls
+flake8
+tox

--- a/tmdb3/__init__.py
+++ b/tmdb3/__init__.py
@@ -40,7 +40,7 @@ for search and retrieval of text metadata and image URLs from TMDB.
 Preliminary API specifications can be found at
 http://help.themoviedb.org/kb/api/about-3"""
 
-__version__ = "v0.7.2"
+__version__ = "0.8.0"
 
 __classifiers__ = [
     "Development Status :: 5 - Production/Stable",

--- a/tmdb3/__init__.py
+++ b/tmdb3/__init__.py
@@ -49,6 +49,7 @@ __classifiers__ = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = pep8,py3
+basepython = python3
+
+[testenv]
+deps =
+    httpretty
+    pytest
+    pytest-cov==2.5.0
+    python-coveralls
+
+commands = pytest {posargs:tests/} --doctest-modules --cov tmdb3 --cov-report term-missing
+
+[testenv:pep8]
+deps = flake8
+commands = flake8 tmdb3/ tests/
+
+[flake8]
+ignore =
+    E123, E124, E126,
+    E226,
+    E402, E403, E405,
+    F401,F403,F405,F841,
+    E722,
+    W503,W504


### PR DESCRIPTION
Here we bump the version number of the project to `0.8.0` and perform some more changes:
  - makes the CI tests with **tox**
  - uses **flake8** to perform the pep8 tests (added some exceptions for pep8 tests with flake8)
  - adds **badges**
  - adds CI tests for python 3.8