### PR TITLE
:alien: Add support for python >= 3.8 when importing Iterator and Sequence

### DIFF
--- a/tmdb3/pager.py
+++ b/tmdb3/pager.py
@@ -6,7 +6,14 @@
 # Author: Raymond Wagner
 # -----------------------
 from abc import ABC
-from collections import Sequence, Iterator
+try:
+    from collections.abc import Iterator
+except ImportError:
+    from collections import Iterator
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 
 class PagedIterator(Iterator):


### PR DESCRIPTION
Because importing from `collections` has been deprecated and removed since python 3.8